### PR TITLE
Bug Fix: Far Camera Blending Not Working

### DIFF
--- a/Assets/Scripts/Constants.cs
+++ b/Assets/Scripts/Constants.cs
@@ -20,6 +20,7 @@ public static class Constants
 
     public const string CHEATS_STARTMISSIONCAFETERIA1 = "Cheats/MissionCafeteria1/Start";
     public const string CHEATS_ENDMISSIONCAFETERIA1 = "Cheats/MissionCafeteria1/End";
+    public const string CHEATS_CAMERA_BLENDTOFAR = "Cheats/Camera/BlendToFarCamera";
 
     public const string SCENE_MAIN = "MAIN";
 }

--- a/Assets/Scripts/Editor/CameraCheats.cs
+++ b/Assets/Scripts/Editor/CameraCheats.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+public class CameraCheats : MonoBehaviour
+{
+    [MenuItem(Constants.CHEATS_CAMERA_BLENDTOFAR, true)]
+    public static bool ValidateBlendToFar()
+    {
+        return Application.isPlaying && CameraManager.Instance;
+    }
+
+    [MenuItem(Constants.CHEATS_CAMERA_BLENDTOFAR)]
+    public static void BlendToFar()
+    {
+        CameraManager.Instance.BlendToFarCameraForSeconds(1f);
+    }
+}

--- a/Assets/Scripts/Editor/CameraCheats.cs.meta
+++ b/Assets/Scripts/Editor/CameraCheats.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 55994092a3f390b4390cf9a41af3af6c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Missions/MissionCafeteria1/MissionCafeteria1.cs
+++ b/Assets/Scripts/Missions/MissionCafeteria1/MissionCafeteria1.cs
@@ -249,7 +249,7 @@ public class MissionCafeteria1 : AMission
 
             SpawnEnemies(missionCriticalInteractables[interactableIndex].enemiesToSpawnIfLastCollected);
 
-            StartCoroutine(CameraManager.Instance.BlendToFarCameraForSeconds(2));
+            CameraManager.Instance.BlendToFarCameraForSeconds(2);
 
             AlertMissionComplete();
         }


### PR DESCRIPTION
Fixes the issue Finnbarr logged: 
Fixes #80 

TLDR; Awareness affecting camera distance also affected the far camera, so I worked on keeping the internal state of `canZoom` in `CameraManager` and this toggles off/on during the far camera blend to and from. 

---

This fix needed a good amount of abstraction in `CameraManager` to keep it at least somewhat non-hardcoded.
* Main idea is that for some blending operations, like blending to the far camera for some time, do not need to alert listeners like, the player which will disable movement and stuff during the camera movement.
  * We have two event types currently, `OnBlendingStart` and `OnBlendingComplete`
* But internally, we need to listen to these events to now stop the ability for outside sources to affect things like, zoom level, which was the main issue for this bug.
* So now we have internal events, which are private, in addition to the public-facing events we already have.
* Now when we want to blend cameras, we can stick with the default public events, or pass in our own internal events and listen to those, which are guaranteed to not be listened to by any outside sources.