### PR TITLE
Set Both Shake Properties to Have Named Refs

### DIFF
--- a/Assets/Shaders/Shake.shadergraph
+++ b/Assets/Shaders/Shake.shadergraph
@@ -4,19 +4,13 @@
             "typeInfo": {
                 "fullName": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty"
             },
-            "JSONnodeData": "{\n    \"m_Guid\": {\n        \"m_GuidSerialized\": \"ffc7a743-7e6e-47d5-8c6f-5ac9b5a07d04\"\n    },\n    \"m_Name\": \"ShakeFXTime\",\n    \"m_DefaultReferenceName\": \"Vector1_9A63CADE\",\n    \"m_OverrideReferenceName\": \"\",\n    \"m_GeneratePropertyBlock\": true,\n    \"m_Precision\": 0,\n    \"m_GPUInstanced\": false,\n    \"m_Hidden\": false,\n    \"m_Value\": 1.0,\n    \"m_FloatType\": 0,\n    \"m_RangeValues\": {\n        \"x\": 0.0,\n        \"y\": 1.0\n    }\n}"
+            "JSONnodeData": "{\n    \"m_Guid\": {\n        \"m_GuidSerialized\": \"ac97335f-4d7e-4e78-824f-06be03d9b1c5\"\n    },\n    \"m_Name\": \"ShakeFrequency\",\n    \"m_DefaultReferenceName\": \"Vector1_2EBF8488\",\n    \"m_OverrideReferenceName\": \"_ShakeFrequency\",\n    \"m_GeneratePropertyBlock\": true,\n    \"m_Precision\": 0,\n    \"m_GPUInstanced\": false,\n    \"m_Hidden\": false,\n    \"m_Value\": 2.0,\n    \"m_FloatType\": 0,\n    \"m_RangeValues\": {\n        \"x\": 0.0,\n        \"y\": 1.0\n    }\n}"
         },
         {
             "typeInfo": {
                 "fullName": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty"
             },
-            "JSONnodeData": "{\n    \"m_Guid\": {\n        \"m_GuidSerialized\": \"ac97335f-4d7e-4e78-824f-06be03d9b1c5\"\n    },\n    \"m_Name\": \"ShakeFrequency\",\n    \"m_DefaultReferenceName\": \"Vector1_2EBF8488\",\n    \"m_OverrideReferenceName\": \"\",\n    \"m_GeneratePropertyBlock\": true,\n    \"m_Precision\": 0,\n    \"m_GPUInstanced\": false,\n    \"m_Hidden\": false,\n    \"m_Value\": 2.0,\n    \"m_FloatType\": 0,\n    \"m_RangeValues\": {\n        \"x\": 0.0,\n        \"y\": 1.0\n    }\n}"
-        },
-        {
-            "typeInfo": {
-                "fullName": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty"
-            },
-            "JSONnodeData": "{\n    \"m_Guid\": {\n        \"m_GuidSerialized\": \"1a6d8414-f4bd-4537-8c24-bc323bedbf97\"\n    },\n    \"m_Name\": \"ShakeAmplitude\",\n    \"m_DefaultReferenceName\": \"Vector1_3338B8F9\",\n    \"m_OverrideReferenceName\": \"\",\n    \"m_GeneratePropertyBlock\": true,\n    \"m_Precision\": 0,\n    \"m_GPUInstanced\": false,\n    \"m_Hidden\": false,\n    \"m_Value\": 0.05000000074505806,\n    \"m_FloatType\": 0,\n    \"m_RangeValues\": {\n        \"x\": 0.0,\n        \"y\": 1.0\n    }\n}"
+            "JSONnodeData": "{\n    \"m_Guid\": {\n        \"m_GuidSerialized\": \"1a6d8414-f4bd-4537-8c24-bc323bedbf97\"\n    },\n    \"m_Name\": \"ShakeAmplitude\",\n    \"m_DefaultReferenceName\": \"Vector1_3338B8F9\",\n    \"m_OverrideReferenceName\": \"_ShakeAmplitude\",\n    \"m_GeneratePropertyBlock\": true,\n    \"m_Precision\": 0,\n    \"m_GPUInstanced\": false,\n    \"m_Hidden\": false,\n    \"m_Value\": 0.05000000074505806,\n    \"m_FloatType\": 0,\n    \"m_RangeValues\": {\n        \"x\": 0.0,\n        \"y\": 1.0\n    }\n}"
         }
     ],
     "m_SerializedKeywords": [],


### PR DESCRIPTION
For @justineechen to be able to work with these properties through script.

The two properties are `_ShakeFrequency` and `_ShakeAmplitude` which can be accessed through script, and if based on the player's distance from the object, the shake amplitude can be lerped between 0 and maybe 0.05? Something like that I'm assuming has to be done.

![image](https://user-images.githubusercontent.com/11907795/74804462-56118f80-52ae-11ea-8ef7-c91c46afa7c2.png)
