### PR TITLE
Properly Destroy Throwables After Throwing

### DIFF
--- a/Assets/Scripts/InteractableAutoSpawner.cs
+++ b/Assets/Scripts/InteractableAutoSpawner.cs
@@ -14,11 +14,14 @@ public class InteractableAutoSpawner : MonoBehaviour
     public int spawnCount = 5;
     [SerializeField] public InteractableType interactableType;
 
+    private List<GameObject> currentInteractables;
+
     void Start()
     {
-        for(int i = 0; i < spawnCount; i++)
+        currentInteractables = new List<GameObject>();
+        for (int i = 0; i < spawnCount; i++)
         {
-            SpawnInteractable();
+            currentInteractables.Add(SpawnInteractable());
         }
 
         if (interactableType == InteractableType.Throwable)
@@ -27,7 +30,7 @@ public class InteractableAutoSpawner : MonoBehaviour
         }
     }
 
-    private void SpawnInteractable()
+    private GameObject SpawnInteractable()
     {
         GameObject spawnedInteractable = Instantiate(prefab, transform);
         spawnedInteractable.transform.localPosition = Vector3.zero;
@@ -46,10 +49,15 @@ public class InteractableAutoSpawner : MonoBehaviour
                 Debug.LogError($"Unknown InteractableType: {interactableType}");
                 break;
         }
+
+        return spawnedInteractable;
     }
 
     private void OnInteractEnd(Interactable source)
     {
-        SpawnInteractable();
+        if (currentInteractables.Remove(source.gameObject))
+        {
+            currentInteractables.Add(SpawnInteractable());
+        }
     }
 }

--- a/Assets/Scripts/InteractableAutoSpawner.cs
+++ b/Assets/Scripts/InteractableAutoSpawner.cs
@@ -50,8 +50,6 @@ public class InteractableAutoSpawner : MonoBehaviour
 
     private void OnInteractEnd(Interactable source)
     {
-        // TODO: Have a nice fade out shader animation and delete afterwards
-        Destroy(source.gameObject, 5f);
         SpawnInteractable();
     }
 }

--- a/Assets/Scripts/PlayerManager.cs
+++ b/Assets/Scripts/PlayerManager.cs
@@ -11,6 +11,7 @@ public class PlayerManager : MonoBehaviour
 
     [Header("Throwables")]
     public Transform throwPosition;
+    public float throwableDestroyTime = 5f;
     public float throwMultiplier = 0.08f;
     public float angleIncreaseSpeed = 45f;
     public float minThrowAngle = 0f;
@@ -130,6 +131,9 @@ public class PlayerManager : MonoBehaviour
         launchArcRenderer.RenderArc(0f);
 
         OnThrow?.Invoke(current.GetComponent<Interactable>());
+
+        // TODO: Have a nice fade out shader animation and delete after this time elapses
+        Destroy(current, throwableDestroyTime);
     }
 
     private float DistToClosestEnemy()


### PR DESCRIPTION
Addresses and fixes #88 

Before the interactable spawner logic was meant to delete only the objects it spawned after they were thrown / interacted with, but a bug lead to every object being deleted instead, which ended up being the behavior we wanted anyways so this is just properly handling deletion in the right place.