### PR TITLE
Fixed LoadConversation Issue

### DIFF
--- a/Assets/Scripts/Interactables/Dialogue/DialogueInteractable.cs
+++ b/Assets/Scripts/Interactables/Dialogue/DialogueInteractable.cs
@@ -67,6 +67,7 @@ public class DialogueInteractable : Interactable
     private bool ContinueConversation()
     {
         //DisplayLine();
+        //activeLineIndex += 1;
         return activeLineIndex < conversation.lines.Length;
     }
 

--- a/Assets/Scripts/Interactables/Dialogue/NPCDialogue/NPCInteractable.cs
+++ b/Assets/Scripts/Interactables/Dialogue/NPCDialogue/NPCInteractable.cs
@@ -42,12 +42,19 @@ public class NPCInteractable : DialogueInteractable
     {
         if(IsWithinBoundaryRadius(GameManager.Instance.GetPlayerTransform()))
         {
-            LoadConversation();
+            // Prevent loading during a conversation
+            if (!isConversing && !autoPlaying)
+            {
+                LoadConversation();
+            }
 
             // Autoplay
-            if(conversation.isAutoplayed && !autoPlaying)
+            if(conversation.isAutoplayed)
             {
-                OnInteract();
+                if(!autoPlaying)
+                {
+                    OnInteract();
+                }
             }
             // Enter collider to interact
             else
@@ -111,6 +118,10 @@ public class NPCInteractable : DialogueInteractable
                     ProgressManager.Instance.AddMission(startedMission);
                     startedMission.OnMissionComplete += HandleOnMissionComplete;
                     startedMission.OnMissionReset += HandleOnMissionReset;
+                }
+                else if (startedMission != null && ProgressManager.Instance.GetMissionStatus(startedMission) == MissionStatusCode.Started)
+                {
+                    //Must have this case because it is the catch for a during mission interaction (without this it will go to else)
                 }
                 // Objective of mission has been completed but now talking to NPC to close mission
                 else if (startedMission != null && ProgressManager.Instance.GetMissionStatus(startedMission) == MissionStatusCode.Completed)

--- a/Assets/Scripts/Interactables/Interactable.cs
+++ b/Assets/Scripts/Interactables/Interactable.cs
@@ -37,7 +37,6 @@ public class Interactable : MonoBehaviour, IInteractable
 
                 OnInteract();
             }
-     
         }
     }
 


### PR DESCRIPTION
Super small pull request. Just fixed an issue where next conversation was being loaded when current conversation did not even finish yet. I was able to test it and all conversations for NPCMission1 started and ended correctly.