### PR TITLE
Camera-related Bug Fixes

### DIFF
--- a/Assets/Scenes/MAIN/MAIN.unity
+++ b/Assets/Scenes/MAIN/MAIN.unity
@@ -656,7 +656,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-38110
+  m_Name: pb_Mesh-189448
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -912,7 +912,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289048
+  m_Name: pb_Mesh178674
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -1075,7 +1075,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289422
+  m_Name: pb_Mesh179048
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -1238,7 +1238,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289124
+  m_Name: pb_Mesh178750
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -1401,7 +1401,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289950
+  m_Name: pb_Mesh179578
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -2897,7 +2897,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289474
+  m_Name: pb_Mesh179102
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -4820,7 +4820,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289006
+  m_Name: pb_Mesh178632
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -4983,7 +4983,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh288962
+  m_Name: pb_Mesh178588
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -6811,7 +6811,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-38112
+  m_Name: pb_Mesh-189450
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -7284,7 +7284,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289314
+  m_Name: pb_Mesh178940
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -7447,7 +7447,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289396
+  m_Name: pb_Mesh179022
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -7610,7 +7610,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289072
+  m_Name: pb_Mesh178698
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -8103,8 +8103,8 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 90, y: 40, z: 90}
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 91.43346, y: 40, z: 96.159164}
+  m_Center: {x: 2.2035503, y: 0, z: -0.118118286}
 --- !u!114 &268841620
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8576,7 +8576,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh290096
+  m_Name: pb_Mesh179724
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -9434,7 +9434,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289760
+  m_Name: pb_Mesh179388
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -9960,7 +9960,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289544
+  m_Name: pb_Mesh179168
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -10852,7 +10852,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289200
+  m_Name: pb_Mesh178826
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -11021,7 +11021,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh290214
+  m_Name: pb_Mesh179846
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -11184,7 +11184,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289804
+  m_Name: pb_Mesh179432
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -11723,7 +11723,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh290084
+  m_Name: pb_Mesh179712
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -11886,7 +11886,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh288906
+  m_Name: pb_Mesh178532
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -12049,7 +12049,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh290048
+  m_Name: pb_Mesh179676
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -12832,7 +12832,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh288974
+  m_Name: pb_Mesh178600
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -13425,7 +13425,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289338
+  m_Name: pb_Mesh178964
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -13588,7 +13588,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-534484
+  m_Name: pb_Mesh-188930
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -15479,7 +15479,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh290284
+  m_Name: pb_Mesh179922
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -17149,7 +17149,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh288934
+  m_Name: pb_Mesh178560
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -17312,7 +17312,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289962
+  m_Name: pb_Mesh179590
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -17986,7 +17986,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289710
+  m_Name: pb_Mesh179338
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -18769,7 +18769,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289138
+  m_Name: pb_Mesh178764
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -19552,7 +19552,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289358
+  m_Name: pb_Mesh178984
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -19779,7 +19779,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289290
+  m_Name: pb_Mesh178916
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -21468,7 +21468,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-534486
+  m_Name: pb_Mesh-188932
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -21631,7 +21631,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289744
+  m_Name: pb_Mesh179372
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -22350,7 +22350,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh288892
+  m_Name: pb_Mesh178518
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -22996,7 +22996,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289686
+  m_Name: pb_Mesh179314
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -23159,7 +23159,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289580
+  m_Name: pb_Mesh179204
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -23632,7 +23632,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh290012
+  m_Name: pb_Mesh179640
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -23828,7 +23828,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289630
+  m_Name: pb_Mesh179256
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -24446,7 +24446,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289410
+  m_Name: pb_Mesh179036
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -25713,7 +25713,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh290144
+  m_Name: pb_Mesh179772
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -25876,7 +25876,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289458
+  m_Name: pb_Mesh179084
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -27250,7 +27250,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh290334
+  m_Name: pb_Mesh179970
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -28207,7 +28207,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289660
+  m_Name: pb_Mesh179288
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -31816,7 +31816,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289560
+  m_Name: pb_Mesh179184
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -32579,7 +32579,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289084
+  m_Name: pb_Mesh178710
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -33337,7 +33337,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289244
+  m_Name: pb_Mesh178870
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -33500,7 +33500,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh288988
+  m_Name: pb_Mesh178614
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -33663,7 +33663,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289642
+  m_Name: pb_Mesh179268
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -34136,7 +34136,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289936
+  m_Name: pb_Mesh179564
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -34299,7 +34299,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289602
+  m_Name: pb_Mesh179228
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -34462,7 +34462,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289900
+  m_Name: pb_Mesh179528
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -34631,7 +34631,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289986
+  m_Name: pb_Mesh179614
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -35343,7 +35343,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289722
+  m_Name: pb_Mesh179350
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -35506,7 +35506,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289974
+  m_Name: pb_Mesh179602
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -37868,7 +37868,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289266
+  m_Name: pb_Mesh178892
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -39075,7 +39075,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289162
+  m_Name: pb_Mesh178788
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -39438,7 +39438,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289698
+  m_Name: pb_Mesh179326
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -39601,7 +39601,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289998
+  m_Name: pb_Mesh179626
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -39811,7 +39811,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh288858
+  m_Name: pb_Mesh178484
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -39974,7 +39974,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh288880
+  m_Name: pb_Mesh178506
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -40137,7 +40137,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh290184
+  m_Name: pb_Mesh179816
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -40920,7 +40920,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289326
+  m_Name: pb_Mesh178952
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -41083,7 +41083,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh290118
+  m_Name: pb_Mesh179746
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -41246,7 +41246,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh288808
+  m_Name: pb_Mesh178434
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -41958,7 +41958,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289278
+  m_Name: pb_Mesh178904
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -42127,7 +42127,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh288846
+  m_Name: pb_Mesh178472
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -42290,7 +42290,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289842
+  m_Name: pb_Mesh179470
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -42453,7 +42453,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh288918
+  m_Name: pb_Mesh178544
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -42926,7 +42926,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289102
+  m_Name: pb_Mesh178728
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -43399,7 +43399,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289514
+  m_Name: pb_Mesh179142
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -43562,7 +43562,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289218
+  m_Name: pb_Mesh178844
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -43824,7 +43824,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-532336
+  m_Name: pb_Mesh-186846
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -44297,7 +44297,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289188
+  m_Name: pb_Mesh178814
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -44460,7 +44460,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289614
+  m_Name: pb_Mesh179240
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -44664,7 +44664,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh-532334
+  m_Name: pb_Mesh-186844
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -44827,7 +44827,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh290298
+  m_Name: pb_Mesh179936
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -44990,7 +44990,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289384
+  m_Name: pb_Mesh179010
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -45153,7 +45153,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh290158
+  m_Name: pb_Mesh179786
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -45626,7 +45626,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh290240
+  m_Name: pb_Mesh179872
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -45789,7 +45789,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh288946
+  m_Name: pb_Mesh178572
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -45952,7 +45952,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh290312
+  m_Name: pb_Mesh179952
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -46650,7 +46650,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289864
+  m_Name: pb_Mesh179492
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -47001,7 +47001,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh290024
+  m_Name: pb_Mesh179652
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -47978,7 +47978,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289674
+  m_Name: pb_Mesh179302
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -48530,7 +48530,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh290366
+  m_Name: pb_Mesh180002
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -49078,7 +49078,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh290346
+  m_Name: pb_Mesh179982
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -50152,7 +50152,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh289446
+  m_Name: pb_Mesh179072
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2

--- a/Assets/Scripts/CameraZone.cs
+++ b/Assets/Scripts/CameraZone.cs
@@ -47,8 +47,11 @@ public class CameraZone : MonoBehaviour
 
     private void AlertBlendingComplete(CinemachineVirtualCamera fromCamera, CinemachineVirtualCamera toCamera)
     {
-        CameraManager.Instance.OnBlendingComplete -= AlertBlendingComplete;
-        OnPlayerEnter?.Invoke();
+        if (toCamera == mainCamera)  // we do not want to care about unrelated camera blending events
+        {
+            CameraManager.Instance.OnBlendingComplete -= AlertBlendingComplete;
+            OnPlayerEnter?.Invoke();
+        }
     }
 
     private void OnTriggerExit(Collider other)

--- a/Assets/Scripts/Missions/MissionCafeteria1/MissionCafeteria1.cs
+++ b/Assets/Scripts/Missions/MissionCafeteria1/MissionCafeteria1.cs
@@ -172,20 +172,19 @@ public class MissionCafeteria1 : AMission
         //
         // So we can just destroy it after the animation time is over and it should switch back to whatever the current camera was
         RegionManager.Instance.kitchen.OnPlayerEnter -= StartCutscene;
+
+        if (startCutscenePlayed) return;
+
         startCutscenePlayed = true;
 
-        if (!startCutsceneCamera || instantiatedMissionInteractables.Count == 0)
-        {
-            return;
-        }
+        if (!startCutsceneCamera || instantiatedMissionInteractables.Count == 0) return;
+
+        GameManager.Instance.GetPlayerController().CanMove = false;
 
         GameObject instantiatedCutscenePrefab = Instantiate(startCutsceneCamera);
         CinemachineVirtualCamera virtualCamera = instantiatedCutscenePrefab.GetComponentInChildren<CinemachineVirtualCamera>();
         Animator virtualCameraAnim = instantiatedCutscenePrefab.GetComponentInChildren<Animator>();
-        if (!virtualCamera || !virtualCameraAnim)
-        {
-            return;
-        }
+        if (!virtualCamera || !virtualCameraAnim) return;
 
         virtualCamera.LookAt = instantiatedMissionInteractables[0].transform;
 
@@ -203,14 +202,13 @@ public class MissionCafeteria1 : AMission
         Destroy(cutsceneObject);
 
         UIManager.Instance.FadeIn();
+
+        GameManager.Instance.GetPlayerController().CanMove = true;
     }
 
     private void OnCollideWithPlayer()
     {
-        if (isRestarting)
-        {
-            return;
-        }
+        if (isRestarting) return;
 
         isRestarting = true;
 
@@ -221,7 +219,7 @@ public class MissionCafeteria1 : AMission
         UIManager.Instance.OnFadingComplete += OnFadingCompleteRestartMission;
         UIManager.Instance.FadeOut();
 
-        // Tell any listeners (looking at you ProgressManager) that we need to reste whatever mission status
+        // Tell any listeners (looking at you ProgressManager) that we need to reset whatever mission status
         AlertMissionReset();
     }
 
@@ -229,9 +227,12 @@ public class MissionCafeteria1 : AMission
     {
         UIManager.Instance.OnFadingComplete -= OnFadingCompleteRestartMission;
 
+        bool alreadyPlayedCutscene = startCutscenePlayed;
+
         Cleanup();
         Initialize();
         GameManager.Instance.GetPlayerTransform().position = respawnPosition;
+        startCutscenePlayed = alreadyPlayedCutscene;
 
         isRestarting = false;
 

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -13,7 +13,6 @@ public class PlayerController : MonoBehaviour
     [HideInInspector] public float movementSpeed;
     [HideInInspector] public float turnSpeed;
     private Rigidbody rb;
-    private PlayerManager playerManager;
 
     private Vector3 movement;
     public bool CanMove { get; set; } = true;
@@ -23,7 +22,6 @@ public class PlayerController : MonoBehaviour
         movementSpeed = baseMovementSpeed;
         turnSpeed = baseTurnSpeed;
         rb = Utils.GetRequiredComponent<Rigidbody>(this);
-        playerManager = Utils.GetRequiredComponent<PlayerManager>(this);
 
         if (CameraManager.Instance)
         {


### PR DESCRIPTION
Fixes #102 
* Restricting player movement now during the cutscene to show the dentures

Fixes #103 
* Resized the area of the kitchen camera zone so that it cannot be entered from the dining hall

Fixes #104 
* Reworked the camera distance system in the `CameraManager` to be more stable and consistent
  * (This system is what is used with awareness to zoom in and out the camera to zoom in and out the current camera)

+ misc. code cleanup here and there