### PR TITLE
Temporary fix for issue where UI text was being disappearing mid convo

### DIFF
--- a/Assets/Scripts/Interactables/Interactable.cs
+++ b/Assets/Scripts/Interactables/Interactable.cs
@@ -22,6 +22,7 @@ public class Interactable : MonoBehaviour, IInteractable
     public delegate void OnInteractEventHandler(Interactable source);
     public event OnInteractEventHandler OnInteractEnd;
 
+
     protected virtual void Start()
     {
         player = GameManager.Instance.GetPlayerTransform().gameObject;

--- a/Assets/Scripts/PlayerManager.cs
+++ b/Assets/Scripts/PlayerManager.cs
@@ -32,6 +32,9 @@ public class PlayerManager : MonoBehaviour
     public delegate void OnPickupEventHandler(GameObject source);
     public event OnPickupEventHandler OnPickup;
 
+    public delegate void OnInteractEventHandler(DialogueInteractable source);
+    public event OnInteractEventHandler OnInteractBegin;
+
     private void Start()
     {
         launchArcRenderer = GetComponentInChildren<LaunchArcRenderer>();
@@ -206,5 +209,10 @@ public class PlayerManager : MonoBehaviour
     public void HandleDecreaseAwakeness()
     {
         spawnedCoroutines.Add(StartCoroutine(UIManager.Instance.staminaBar.DecreaseStaminaBy(awakenessDecrease)));
+    }
+
+    public void InteractPlayer(DialogueInteractable source)
+    {
+        OnInteractBegin?.Invoke(source);
     }
 }


### PR DESCRIPTION
This issue happens when there is currently a conversation that is autoplaying and player tries to interact with another NPC because the autoplay NPC conversation will hide Birdie's SpeechbBubble when displaying its next conversation.

Resolved this by ending current autoplay conversations on interact.