### PR TITLE
Added Auto Initiate Conversation Functionality

### DIFF
--- a/Assets/Dialogue/Conversations/NPC1 Give Mission.asset
+++ b/Assets/Dialogue/Conversations/NPC1 Give Mission.asset
@@ -12,8 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 85ee462f4b7334f118fe3d0f9f6176c1, type: 3}
   m_Name: NPC1 Give Mission
   m_EditorClassIdentifier: 
-  isAutoplayed: 0
-  shouldFollow: 0
+  autoInitiate: 1
+  conversationAutoplayed: 0
+  shouldFollow: 1
   lines:
   - isBirdie: 0
     text: Birdie, there you are!

--- a/Assets/Dialogue/Conversations/TutorialDistractingAutoPlayNPCConversation.asset
+++ b/Assets/Dialogue/Conversations/TutorialDistractingAutoPlayNPCConversation.asset
@@ -12,7 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 85ee462f4b7334f118fe3d0f9f6176c1, type: 3}
   m_Name: TutorialDistractingAutoPlayNPCConversation
   m_EditorClassIdentifier: 
-  isAutoplayed: 1
+  autoInitiate: 0
+  conversationAutoplayed: 1
   shouldFollow: 1
   lines:
   - isBirdie: 0

--- a/Assets/Dialogue/Conversations/TutorialDistractingAutoPlayNPCConversation.asset
+++ b/Assets/Dialogue/Conversations/TutorialDistractingAutoPlayNPCConversation.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: TutorialDistractingAutoPlayNPCConversation
   m_EditorClassIdentifier: 
   autoInitiate: 0
-  conversationAutoplayed: 1
+  autoplayConversation: 1
   shouldFollow: 1
   lines:
   - isBirdie: 0

--- a/Assets/Scripts/Interactables/Dialogue/Conversation.cs
+++ b/Assets/Scripts/Interactables/Dialogue/Conversation.cs
@@ -15,7 +15,7 @@ public struct Line
 public class Conversation : ScriptableObject
 {
     public bool autoInitiate = false;
-    public bool conversationAutoplayed = false;
+    public bool autoplayConversation = false;
     public bool shouldFollow = false;
     public Line[] lines;
 }

--- a/Assets/Scripts/Interactables/Dialogue/Conversation.cs
+++ b/Assets/Scripts/Interactables/Dialogue/Conversation.cs
@@ -14,7 +14,8 @@ public struct Line
 [CreateAssetMenu(fileName = "New Conversation", menuName = "Conversation")]
 public class Conversation : ScriptableObject
 {
-    public bool isAutoplayed = false;
+    public bool autoInitiate = false;
+    public bool conversationAutoplayed = false;
     public bool shouldFollow = false;
     public Line[] lines;
 }

--- a/Assets/Scripts/Interactables/Dialogue/Conversation.cs
+++ b/Assets/Scripts/Interactables/Dialogue/Conversation.cs
@@ -14,8 +14,9 @@ public struct Line
 [CreateAssetMenu(fileName = "New Conversation", menuName = "Conversation")]
 public class Conversation : ScriptableObject
 {
-    public bool autoInitiate = false;
+    [Header("Note: Autoplay Conversation takes precedence over Auto Initiate")]
     public bool autoplayConversation = false;
+    public bool autoInitiate = false;
     public bool shouldFollow = false;
     public Line[] lines;
 }

--- a/Assets/Scripts/Interactables/Dialogue/NPCDialogue/NPCInteractable.cs
+++ b/Assets/Scripts/Interactables/Dialogue/NPCDialogue/NPCInteractable.cs
@@ -68,8 +68,9 @@ public class NPCInteractable : DialogueInteractable
                 TriggerFollow(player);
             }
 
+
             // Autoplay
-            if (conversation.isAutoplayed)
+            if (conversation.conversationAutoplayed)
             {
                 if(!autoPlaying)
                 {
@@ -80,6 +81,12 @@ public class NPCInteractable : DialogueInteractable
             // Enter collider to interact
             else
             {
+                if(conversation.autoInitiate && !isConversing)
+				{
+                    interactableOn = true;
+                    OnInteract();
+				}
+
                 base.Update();
             }
         }
@@ -167,7 +174,7 @@ public class NPCInteractable : DialogueInteractable
                     return;
                 }
             }
-            if (!conversation.shouldFollow && !conversation.isAutoplayed)
+            if (!conversation.shouldFollow && !conversation.conversationAutoplayed)
             {
                 NPCFacePlayer();
             }

--- a/Assets/Scripts/Interactables/Dialogue/NPCDialogue/NPCInteractable.cs
+++ b/Assets/Scripts/Interactables/Dialogue/NPCDialogue/NPCInteractable.cs
@@ -70,7 +70,7 @@ public class NPCInteractable : DialogueInteractable
 
 
             // Autoplay
-            if (conversation.conversationAutoplayed)
+            if (conversation.autoplayConversation)
             {
                 if(!autoPlaying)
                 {
@@ -174,7 +174,7 @@ public class NPCInteractable : DialogueInteractable
                     return;
                 }
             }
-            if (!conversation.shouldFollow && !conversation.conversationAutoplayed)
+            if (!conversation.shouldFollow && !conversation.autoplayConversation)
             {
                 NPCFacePlayer();
             }

--- a/Assets/Scripts/Interactables/Interactable.cs
+++ b/Assets/Scripts/Interactables/Interactable.cs
@@ -12,7 +12,7 @@ public class Interactable : MonoBehaviour, IInteractable
     public RectTransform interactTransform;
 
     protected bool enableInteract = true;
-    private bool interactableOn = false;
+    protected bool interactableOn = false;
     protected bool continueInteracting = false;
 
     public float interactRadius = Constants.INTERACT_POPUP_RADIUS;
@@ -32,7 +32,7 @@ public class Interactable : MonoBehaviour, IInteractable
     {
         withinInteractRadius = IsWithinRadius(transform.position, player.transform, interactRadius);
 
-        if (!interactableOn && withinInteractRadius)
+        if (!interactableOn && withinInteractRadius && !continueInteracting)
         {
             interactableOn = true;
             ShowInteractUI();


### PR DESCRIPTION
Conversations can now be auto initiated by selecting it in the conversation asset. 
* Note: `Autoplay Conversation` take precedence over `Auto Initiate` so if you set both of them to true, only autoplay conversation will happen.

<img width="402" alt="Screen Shot 2020-03-03 at 4 25 56 PM" src="https://user-images.githubusercontent.com/28247345/75821196-d1257c00-5d6b-11ea-986e-ebe29cc680a9.png">

Fixes #150
Fixes #149