### PR TITLE
Changed the current alpha to be dependent on the current image alpha …

### DIFF
--- a/Assets/Scripts/StaminaBar.cs
+++ b/Assets/Scripts/StaminaBar.cs
@@ -129,7 +129,7 @@ public class StaminaBar : MonoBehaviour
 
     private IEnumerator FadeAlphaCoroutine(float startAlpha, float endAlpha, Image image)
     {
-        float currentAlpha = startAlpha;
+        float currentAlpha = image.color.a;
         while (Mathf.Abs(currentAlpha - startAlpha) < Mathf.Abs(startAlpha - endAlpha))
         {
             image.color = new Color(image.color.r, image.color.g, image.color.b, currentAlpha);


### PR DESCRIPTION
…so that the stamina bar does not flash going from one restricted zone to another

Addressing https://github.com/FinnbarrOC/EspionAge/issues/164