### PR TITLE
RegionManager + CameraZone Refactor

### DIFF
--- a/Assets/Scripts/CameraZone.cs
+++ b/Assets/Scripts/CameraZone.cs
@@ -8,94 +8,19 @@ public class CameraZone : MonoBehaviour
 {
     public CinemachineVirtualCamera mainCamera;
     public bool isRestricted;
-    
-    [Header("Fog Particles")]
-    public List<ParticleSystem> fogs;
-    public float enabledFogAlpha = 50f / 255f;
-    public float disabledFogAlpha = 0f;
-    public float fadeSpeed = 0.1f;
-
-    public delegate void EnterAction();
-    public delegate void ExitAction();
-    public event EnterAction OnPlayerEnter;
-    public event ExitAction OnPlayerExit;
-
-    private void Start()
-    {
-        fogs.ForEach(fog =>
-        {
-            fog.gameObject.SetActive(GameManager.Instance.enableFog);
-        });
-    }
 
     private void OnTriggerEnter(Collider other)
     {
         if (other.CompareTag(Constants.TAG_PLAYER))
         {
-            if (isRestricted)
-            {
-                UIManager.Instance.staminaBar.FadeIn();
-            } 
-            else
-            {
-                UIManager.Instance.staminaBar.FadeOut();
-            }
-            // so if there is no mainCamera set, we will just keep whatever the current camera is (which may not be preferable in most cases)
-            if (mainCamera)
-            {
-                CameraManager.Instance.OnBlendingComplete += AlertBlendingComplete;
-                CameraManager.Instance.BlendTo(mainCamera);
-            }
-
-            if (GameManager.Instance.enableFog)
-            {
-                StartCoroutine(FadeFog(enabledFogAlpha, disabledFogAlpha));
-            }
+            RegionManager.Instance.ReportPlayerEnterZone(this);
         }
     }
-
-    private void AlertBlendingComplete(CinemachineVirtualCamera fromCamera, CinemachineVirtualCamera toCamera)
-    {
-        if (toCamera == mainCamera)  // we do not want to care about unrelated camera blending events
-        {
-            CameraManager.Instance.OnBlendingComplete -= AlertBlendingComplete;
-            OnPlayerEnter?.Invoke();
-        }
-    }
-
     private void OnTriggerExit(Collider other)
     {
         if (other.CompareTag(Constants.TAG_PLAYER))
         {
-            OnPlayerExit?.Invoke();
-
-            if (GameManager.Instance.enableFog)
-            {
-                StartCoroutine(FadeFog(disabledFogAlpha, enabledFogAlpha));
-            }
-        }
-    }
-
-    private IEnumerator FadeFog(float startAlpha, float endAlpha)
-    {
-        IEnumerable<Color> startColors = fogs.Select(fog =>
-            new Color(fog.main.startColor.color.r, fog.main.startColor.color.g, fog.main.startColor.color.b, startAlpha));
-        IEnumerable<Color> endColors = fogs.Select(fog => 
-            new Color(fog.main.startColor.color.r, fog.main.startColor.color.g, fog.main.startColor.color.b, endAlpha));
-
-        float t = 0f;
-        while (t < 1f)
-        {
-            t += fadeSpeed;
-            
-            for (int i = 0; i < fogs.Count; i++)
-            {
-                var main = fogs[i].main;
-                main.startColor = Color.Lerp(startColors.ElementAt(i), endColors.ElementAt(i), t);
-
-            }
-
-            yield return null;
+            RegionManager.Instance.ReportPlayerExitZone(this);
         }
     }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -16,7 +16,6 @@ public class GameManager : Singleton<GameManager>
     [Header("Game Settings")]
     public bool enableGameStart = false;
     public SkipSettings skipSettings;
-    public bool enableFog = false;
 
     private PlayerManager playerManager;
     private PlayerController playerController;

--- a/Assets/Scripts/Missions/MissionKitchen1.cs
+++ b/Assets/Scripts/Missions/MissionKitchen1.cs
@@ -83,7 +83,7 @@ public class MissionKitchen1 : AMission
         SpawnInteractables(missionCriticalInteractables);
         SpawnEnemies(startEnemies);
 
-        RegionManager.Instance.kitchen.OnPlayerEnter += StartCutscene;
+        RegionManager.Instance.OnPlayerEnterZone += StartCutscene;
     }
 
     protected override void Cleanup()
@@ -97,7 +97,7 @@ public class MissionKitchen1 : AMission
 
         if (!startCutscenePlayed && RegionManager.Instance)
         {
-            RegionManager.Instance.kitchen.OnPlayerEnter -= StartCutscene;
+            RegionManager.Instance.OnPlayerEnterZone -= StartCutscene;
         }
         startCutscenePlayed = false;
     }
@@ -165,14 +165,16 @@ public class MissionKitchen1 : AMission
         });
     }
 
-    private void StartCutscene()
+    private void StartCutscene(CameraZone zone)
     {
+        if (zone != RegionManager.Instance.kitchen) return;
+
         // The current assumptions are gonna be that:
         //  - we will have a camera where we need to set the look at
         //  - and it will have an already created Animator with a single state that it will start on Awake
         //
         // So we can just destroy it after the animation time is over and it should switch back to whatever the current camera was
-        RegionManager.Instance.kitchen.OnPlayerEnter -= StartCutscene;
+        RegionManager.Instance.OnPlayerEnterZone -= StartCutscene;
 
         if (startCutscenePlayed) return;
 

--- a/Assets/Scripts/Missions/MissionTutorial.cs
+++ b/Assets/Scripts/Missions/MissionTutorial.cs
@@ -175,12 +175,14 @@ public class MissionTutorial : AMission
         //note.spawnedInstance = MissionManager.Instance.SpawnMissionObject(note);
 
         // Cutscene for once they enter the hallway
-        RegionManager.Instance.hallway.OnPlayerEnter += StartDropCutscene;
+        RegionManager.Instance.OnPlayerEnterZone += StartDropCutscene;
     }
 
-    private void StartDropCutscene()
+    private void StartDropCutscene(CameraZone zone)
     {
-        RegionManager.Instance.hallway.OnPlayerEnter -= StartDropCutscene;
+        if (zone != RegionManager.Instance.hallway) return;
+
+        RegionManager.Instance.OnPlayerEnterZone -= StartDropCutscene;
         StartCoroutine(WaitForPlayerMovement());
     }
 
@@ -373,7 +375,7 @@ public class MissionTutorial : AMission
         // Handle the cutscene event handlers
         if (!startCutscenePlayed && RegionManager.Instance)
         {
-            RegionManager.Instance.hallway.OnPlayerEnter -= StartDropCutscene;
+            RegionManager.Instance.OnPlayerEnterZone -= StartDropCutscene;
         }
         startCutscenePlayed = false;
 

--- a/Assets/Scripts/RegionManager.cs
+++ b/Assets/Scripts/RegionManager.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using Cinemachine;
 
 public class RegionManager : Singleton<RegionManager>
 {
@@ -12,4 +13,84 @@ public class RegionManager : Singleton<RegionManager>
 
     [Header("Region Triggers")]
     public RegionTrigger finalHallwayDoor;
+
+    // Treating this list as a stack where the last element is considered "current" zone
+    private List<CameraZone> currentPlayerZones;
+    private CinemachineVirtualCamera currentWaitForBlendingCamera;
+
+    public delegate void EnterZoneAction(CameraZone zone);
+    public delegate void ExitZoneAction(CameraZone zone);
+    public event EnterZoneAction OnPlayerEnterZone;
+    public event ExitZoneAction OnPlayerExitZone;
+
+    private void Awake()
+    {
+        currentPlayerZones = new List<CameraZone>();
+    }
+
+    public CameraZone GetCurrentZone()
+    {
+        if (currentPlayerZones.Count == 0)
+        {
+            return null;
+        }
+        return currentPlayerZones[currentPlayerZones.Count - 1];
+    }
+
+    public void ReportPlayerEnterZone(CameraZone zone)
+    {
+        currentPlayerZones.Add(zone);
+        // OnPlayerEnterZone will be called after camera blending is done within HandleCurentZone
+
+        HandleCurrentZone();
+    }
+
+    public void ReportPlayerExitZone(CameraZone zone)
+    {
+        currentPlayerZones.Remove(zone);
+        OnPlayerExitZone?.Invoke(zone);
+
+        HandleCurrentZone();
+    }
+
+    private void HandleCurrentZone()
+    {
+        CameraZone currentZone = GetCurrentZone();
+        if (!currentZone) return;
+
+        HandleRestrictedZone(currentZone.isRestricted);
+        HandleCameraChange(currentZone.mainCamera);
+    }
+
+    private void HandleRestrictedZone(bool isRestricted)
+    {
+        if (isRestricted)
+        {
+            UIManager.Instance.staminaBar.FadeIn();
+        }
+        else
+        {
+            UIManager.Instance.staminaBar.FadeOut();
+        }
+    }
+
+    private void HandleCameraChange(CinemachineVirtualCamera camera)
+    {
+        if (camera)
+        {
+            currentWaitForBlendingCamera = camera;
+
+            CameraManager.Instance.OnBlendingComplete += AlertBlendingComplete;
+            CameraManager.Instance.BlendTo(camera);
+        }
+    }
+
+    private void AlertBlendingComplete(CinemachineVirtualCamera fromCamera, CinemachineVirtualCamera toCamera)
+    {
+        if (currentWaitForBlendingCamera && toCamera == GetCurrentZone().mainCamera)  // we do not want to care about unrelated camera blending events
+        {
+            CameraManager.Instance.OnBlendingComplete -= AlertBlendingComplete;
+            OnPlayerEnterZone?.Invoke(GetCurrentZone());
+        }
+    }
 }

--- a/Assets/Scripts/RegionManager.cs
+++ b/Assets/Scripts/RegionManager.cs
@@ -16,7 +16,6 @@ public class RegionManager : Singleton<RegionManager>
 
     // Treating this list as a stack where the last element is considered "current" zone
     private List<CameraZone> currentPlayerZones;
-    private CinemachineVirtualCamera currentWaitForBlendingCamera;
 
     public delegate void EnterZoneAction(CameraZone zone);
     public delegate void ExitZoneAction(CameraZone zone);
@@ -28,9 +27,14 @@ public class RegionManager : Singleton<RegionManager>
         currentPlayerZones = new List<CameraZone>();
     }
 
+    public bool PlayerIsInAZone()
+    {
+        return currentPlayerZones.Count > 0;
+    }
+
     public CameraZone GetCurrentZone()
     {
-        if (currentPlayerZones.Count == 0)
+        if (!PlayerIsInAZone())
         {
             return null;
         }
@@ -78,8 +82,6 @@ public class RegionManager : Singleton<RegionManager>
     {
         if (camera)
         {
-            currentWaitForBlendingCamera = camera;
-
             CameraManager.Instance.OnBlendingComplete += AlertBlendingComplete;
             CameraManager.Instance.BlendTo(camera);
         }
@@ -87,7 +89,7 @@ public class RegionManager : Singleton<RegionManager>
 
     private void AlertBlendingComplete(CinemachineVirtualCamera fromCamera, CinemachineVirtualCamera toCamera)
     {
-        if (currentWaitForBlendingCamera && toCamera == GetCurrentZone().mainCamera)  // we do not want to care about unrelated camera blending events
+        if (PlayerIsInAZone() && toCamera == GetCurrentZone().mainCamera)  // we do not want to care about unrelated camera blending events
         {
             CameraManager.Instance.OnBlendingComplete -= AlertBlendingComplete;
             OnPlayerEnterZone?.Invoke(GetCurrentZone());


### PR DESCRIPTION
Before there were issues with the CameraZone because of the colliders maybe being too close to each other so it was hard to track which camera to blend to, and if they got into a zone and then immediately turned back around, it would glitch out sometimes based on the two zone colliders.

This seems to all be fixed now by moving all the logic into the `RegionManager` which keeps track of the current zone with a stack of current zones, where the most recently entered one is the considered the current zone.
* This gets updated as the player enters and exits zones, so if they enter one, the camera will switch to that, but if they didn't leave the last one we will still be keeping track of that in case they turn back or something (seeing the logic might make more sense).

Also have removed fog logic since it seems like we do not need that anymore.

Fixes #179 