### PR TITLE
SpeechBubble Repositioned to Always Stay On Screen

### DIFF
--- a/Assets/Scripts/Interactables/Dialogue/SpeakerUI.cs
+++ b/Assets/Scripts/Interactables/Dialogue/SpeakerUI.cs
@@ -10,11 +10,17 @@ public class SpeakerUI : MonoBehaviour
     public GameObject canvas;
     public TextMeshProUGUI characterName;
     public TextMeshProUGUI conversationText;
+
+    private RectTransform textBoxRect;
+    private Vector2 tbAnchor;
+    private float anchorX;
+    private float anchorY;
     
     private Vector3 textPosition;
 
     void Start()
     {
+        textBoxRect = Utils.GetRequiredComponent<RectTransform>(textBoxContainer);
         Hide();
     }
 
@@ -22,6 +28,18 @@ public class SpeakerUI : MonoBehaviour
     {
         textPosition = Camera.main.WorldToScreenPoint(transform.position);
         textBoxContainer.transform.position = textPosition;
+
+        tbAnchor = textBoxRect.anchoredPosition;
+        anchorX = tbAnchor.x;
+        anchorY = tbAnchor.y;
+
+        anchorX = Mathf.Clamp(anchorX, 0, Mathf.Max(0, Screen.width - textBoxRect.sizeDelta.x));
+        anchorY = Mathf.Clamp(anchorY, -Screen.height + textBoxRect.sizeDelta.y, 0);
+
+        tbAnchor.x = anchorX;
+        tbAnchor.y = anchorY;
+
+        textBoxRect.anchoredPosition = tbAnchor;
     }
 
     public void Show()

--- a/Assets/Scripts/Interactables/Dialogue/SpeakerUI.cs
+++ b/Assets/Scripts/Interactables/Dialogue/SpeakerUI.cs
@@ -13,14 +13,16 @@ public class SpeakerUI : MonoBehaviour
 
     private RectTransform textBoxRect;
     private Vector2 tbAnchor;
-    private float anchorX;
-    private float anchorY;
     
     private Vector3 textPosition;
 
-    void Start()
+    private void Awake()
     {
         textBoxRect = Utils.GetRequiredComponent<RectTransform>(textBoxContainer);
+    }
+
+    void Start()
+    {
         Hide();
     }
 
@@ -30,14 +32,9 @@ public class SpeakerUI : MonoBehaviour
         textBoxContainer.transform.position = textPosition;
 
         tbAnchor = textBoxRect.anchoredPosition;
-        anchorX = tbAnchor.x;
-        anchorY = tbAnchor.y;
 
-        anchorX = Mathf.Clamp(anchorX, 0, Mathf.Max(0, Screen.width - textBoxRect.sizeDelta.x));
-        anchorY = Mathf.Clamp(anchorY, -Screen.height + textBoxRect.sizeDelta.y, 0);
-
-        tbAnchor.x = anchorX;
-        tbAnchor.y = anchorY;
+        tbAnchor.x = Mathf.Clamp(tbAnchor.x, 0, Mathf.Max(0, Screen.width - textBoxRect.sizeDelta.x));
+        tbAnchor.y = Mathf.Clamp(tbAnchor.y, Mathf.Min(-Screen.height + textBoxRect.sizeDelta.y, 0), 0);
 
         textBoxRect.anchoredPosition = tbAnchor;
     }


### PR DESCRIPTION
Fixes #237 

Still not done with all the UI changes to make it perfect but this should handle the issue with dialogue speech bubble going off screen. Still want to be able to:
* Have entire SpeechBubble appear and characters just type
* Rescale Width and Height of SpeechBubble


Also not sure if we want to be able to have an option to decide whether to have it on/off screen incase we want to intentionally have some dialogue go off screen (e.g. 2 nurses talking about something random that is not important to the story). Shouldn't be too hard too implement anyway if we wished to have this.